### PR TITLE
change hr_primary queue to hr_secondary queue

### DIFF
--- a/erpnext/hr/doctype/attendance_request/attendance_request.py
+++ b/erpnext/hr/doctype/attendance_request/attendance_request.py
@@ -17,7 +17,7 @@ class AttendanceRequest(Document):
 			if not getdate(self.from_date)<=getdate(self.half_day_date)<=getdate(self.to_date):
 				frappe.throw(_("Half day date should be in between from date and to date"))
 	def submit(self):
-		self.queue_action('submit',queue_name="hr_primary")
+		self.queue_action('submit',queue_name="hr_secondary")
 
 	def on_submit(self):
 		self.create_attendance()

--- a/erpnext/hr/doctype/leave_application/leave_application.py
+++ b/erpnext/hr/doctype/leave_application/leave_application.py
@@ -44,7 +44,7 @@ class LeaveApplication(Document):
    
 	def submit(self):
 		frappe.db.sql(f"update `tabLeave Application` set status = 'Approved' where name = '{self.name}'",auto_commit=True)
-		self.queue_action('submit',queue_name="hr_primary")
+		self.queue_action('submit',queue_name="hr_secondary")
 
 	def on_submit(self):
 		if self.status == "Open":

--- a/erpnext/hr/doctype/shift_request/shift_request.py
+++ b/erpnext/hr/doctype/shift_request/shift_request.py
@@ -15,7 +15,7 @@ class ShiftRequest(Document):
 		self.validate_dates()
 		self.validate_shift_request_overlap_dates()
 	def submit(self):
-		self.queue_action('submit',queue_name="hr_primary")
+		self.queue_action('submit',queue_name="hr_secondary")
 	def on_submit(self):
 		date_list = self.get_working_days(self.from_date, self.to_date)
 		for date in date_list:


### PR DESCRIPTION
**Modified:**
- erpnext/erpnext/hr/doctype/leave_application/leave_application.py
- erpnext/erpnext/hr/doctype/shift_request/shift_request.py
- erpnext/erpnext/hr/doctype/attendance_request/attendance_request.py
Change the queue from hr_primary to hr_secondary for those jobs whose enqueues on the submit event.