### PR TITLE
Ticket # 120338: Validations before Sales Order are closed on CSD Units

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -184,8 +184,9 @@ class SalesOrder(SellingController):
 	def before_save(self):
 		# Code by Moeiz
 		# Ticket # 120338 (Validate no existing Sales Order is already created for this customer at draft level. If yes, those sales order should be closed)
-
-		if self.is_new():
+		# Only for CSD
+		csd_companies = ("Unit 5", "Unit 5B", "Unit 5C", "Unit 5D", "Unit 8", "Unit 11", "Unit 17", "Unit 17B", "Unit 17C")
+		if self.company and self.company in csd_companies and self.is_new():
 			existing_sales_order_against_customer = frappe.db.sql("""select name from `tabSales Order` where customer = %s and docstatus=0""", self.customer, as_dict=True)
 			if existing_sales_order_against_customer:
 				existing_sales_order_links = ["""<a href="#Form/Sales Order/{0}">{1}</a>""".format(so.name, so.name) for so in existing_sales_order_against_customer]
@@ -362,18 +363,23 @@ class SalesOrder(SellingController):
 			frappe.throw(_("{0} {1} has been modified. Please refresh.").format(self.doctype, self.name))
 
 	def update_status(self, status):
-		# Code by Moeiz
-		# Ticket # 120338 (Validate no existing Delivery Note and sales invoices on draft level for this sales order)
+		"""
+		Code by Moeiz
+		Ticket # 120338 (Validate no existing Delivery Note and sales invoices on draft level for this sales order)
+		Only for CSD
+		"""
 		if status == "Closed":
-			existing_draft_level_dn = frappe.db.sql("""select name from `tabDelivery Note` where sale_order_refrence = %s and docstatus=0""", self.name, as_dict=True)
-			if existing_draft_level_dn:
-				existing_delivery_note_links = ["""<a href="#Form/Delivery Note/{0}">{1}</a>""".format(dn.name, dn.name) for dn in existing_draft_level_dn]
-				frappe.throw(_("Cannot close Sales Order. Delivery Notes: {0} are already at draft for this Sales Order.").format(", ".join(existing_delivery_note_links)))
-			
-			existing_draft_level_si = frappe.db.sql("""select name from `tabSales Invoice` where sale_order_reference = %s and docstatus=0""", self.name, as_dict=True)
-			if existing_draft_level_si:
-				existing_sales_invoice_links = ["""<a href="#Form/Sales Invoice/{0}">{1}</a>""".format(si.name, si.name) for si in existing_draft_level_si]
-				frappe.throw(_("Cannot close Sales Order. Sales Invoices: {0} are already at draft for this Sales Order.").format(", ".join(existing_sales_invoice_links)))
+			csd_companies = ("Unit 5", "Unit 5B", "Unit 5C", "Unit 5D", "Unit 8", "Unit 11", "Unit 17", "Unit 17B", "Unit 17C")
+			if self.company and self.company in csd_companies:
+				existing_draft_level_dn = frappe.db.sql("""select name from `tabDelivery Note` where sale_order_refrence = %s and docstatus=0""", self.name, as_dict=True)
+				if existing_draft_level_dn:
+					existing_delivery_note_links = ["""<a href="#Form/Delivery Note/{0}">{1}</a>""".format(dn.name, dn.name) for dn in existing_draft_level_dn]
+					frappe.throw(_("Cannot close Sales Order. Delivery Notes: {0} are already at draft for this Sales Order.").format(", ".join(existing_delivery_note_links)))
+				
+				existing_draft_level_si = frappe.db.sql("""select name from `tabSales Invoice` where sale_order_reference = %s and docstatus=0""", self.name, as_dict=True)
+				if existing_draft_level_si:
+					existing_sales_invoice_links = ["""<a href="#Form/Sales Invoice/{0}">{1}</a>""".format(si.name, si.name) for si in existing_draft_level_si]
+					frappe.throw(_("Cannot close Sales Order. Sales Invoices: {0} are already at draft for this Sales Order.").format(", ".join(existing_sales_invoice_links)))
 		self.check_modified_date()
 		self.set_status(update=True, status=status)
 		self.update_reserved_qty()

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -182,6 +182,15 @@ class SalesOrder(SellingController):
 				frappe.throw(_("Row #{0}: Set Supplier for item {1}").format(d.idx, d.item_code))
     
 	def before_save(self):
+		# Code by Moeiz
+		# Ticket # 120338 (Validate no existing Sales Order is already created for this customer at draft level. If yes, those sales order should be closed)
+
+		if self.is_new():
+			existing_sales_order_against_customer = frappe.db.sql("""select name from `tabSales Order` where customer = %s and docstatus=0""", self.customer, as_dict=True)
+			if existing_sales_order_against_customer:
+				existing_sales_order_links = ["""<a href="#Form/Sales Order/{0}">{1}</a>""".format(so.name, so.name) for so in existing_sales_order_against_customer]
+				frappe.throw(_("Cannot create Sales Order. Sales Orders: {0} are already at draft for this Customer.").format(", ".join(existing_sales_order_links)))
+
 		from nrp_manufacturing.utils import returnable_items
 		returnables = returnable_items(self.items,self.company)
 		self.returnable_items = {} # reset		
@@ -353,6 +362,18 @@ class SalesOrder(SellingController):
 			frappe.throw(_("{0} {1} has been modified. Please refresh.").format(self.doctype, self.name))
 
 	def update_status(self, status):
+		# Code by Moeiz
+		# Ticket # 120338 (Validate no existing Delivery Note and sales invoices on draft level for this sales order)
+		if status == "Closed":
+			existing_draft_level_dn = frappe.db.sql("""select name from `tabDelivery Note` where sale_order_refrence = %s and docstatus=0""", self.name, as_dict=True)
+			if existing_draft_level_dn:
+				existing_delivery_note_links = ["""<a href="#Form/Delivery Note/{0}">{1}</a>""".format(dn.name, dn.name) for dn in existing_draft_level_dn]
+				frappe.throw(_("Cannot close Sales Order. Delivery Notes: {0} are already at draft for this Sales Order.").format(", ".join(existing_delivery_note_links)))
+			
+			existing_draft_level_si = frappe.db.sql("""select name from `tabSales Invoice` where sale_order_reference = %s and docstatus=0""", self.name, as_dict=True)
+			if existing_draft_level_si:
+				existing_sales_invoice_links = ["""<a href="#Form/Sales Invoice/{0}">{1}</a>""".format(si.name, si.name) for si in existing_draft_level_si]
+				frappe.throw(_("Cannot close Sales Order. Sales Invoices: {0} are already at draft for this Sales Order.").format(", ".join(existing_sales_invoice_links)))
 		self.check_modified_date()
 		self.set_status(update=True, status=status)
 		self.update_reserved_qty()

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -190,7 +190,7 @@ class SalesOrder(SellingController):
 			existing_sales_order_against_customer = frappe.db.sql("""select name from `tabSales Order` where customer = %s and `status` not in ('Closed','Cancelled')""", self.customer, as_dict=True)
 			if existing_sales_order_against_customer:
 				existing_sales_order_links = ["""<a href="#Form/Sales Order/{0}">{1}</a>""".format(so.name, so.name) for so in existing_sales_order_against_customer]
-				frappe.throw(_("Cannot create Sales Order. Sales Orders: {0} are already at draft for this Customer.").format(", ".join(existing_sales_order_links)))
+				frappe.throw(_("Cannot create Sales Order. Kindly close the following sale orders first: {0}").format(", ".join(existing_sales_order_links)))
 
 		from nrp_manufacturing.utils import returnable_items
 		returnables = returnable_items(self.items,self.company)

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -187,7 +187,7 @@ class SalesOrder(SellingController):
 		# Only for CSD
 		csd_companies = ("Unit 5", "Unit 5B", "Unit 5C", "Unit 5D", "Unit 8", "Unit 11", "Unit 17", "Unit 17B", "Unit 17C")
 		if self.company and self.company in csd_companies and self.is_new():
-			existing_sales_order_against_customer = frappe.db.sql("""select name from `tabSales Order` where customer = %s and docstatus=0""", self.customer, as_dict=True)
+			existing_sales_order_against_customer = frappe.db.sql("""select name from `tabSales Order` where customer = %s and `status` not in ('Closed','Cancelled')""", self.customer, as_dict=True)
 			if existing_sales_order_against_customer:
 				existing_sales_order_links = ["""<a href="#Form/Sales Order/{0}">{1}</a>""".format(so.name, so.name) for so in existing_sales_order_against_customer]
 				frappe.throw(_("Cannot create Sales Order. Sales Orders: {0} are already at draft for this Customer.").format(", ".join(existing_sales_order_links)))

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -187,7 +187,7 @@ class SalesOrder(SellingController):
 		# Only for CSD
 		csd_companies = ("Unit 5", "Unit 5B", "Unit 5C", "Unit 5D", "Unit 8", "Unit 11", "Unit 17", "Unit 17B", "Unit 17C")
 		if self.company and self.company in csd_companies and self.is_new():
-			existing_sales_order_against_customer = frappe.db.sql("""select name from `tabSales Order` where customer = %s and `status` not in ('Closed','Cancelled')""", self.customer, as_dict=True)
+			existing_sales_order_against_customer = frappe.db.sql("""select name from `tabSales Order` where customer = %s and `company` in %s and `status` not in ('Closed','Cancelled')""", (self.customer, csd_companies), as_dict=True, debug=True)
 			if existing_sales_order_against_customer:
 				existing_sales_order_links = ["""<a href="#Form/Sales Order/{0}">{1}</a>""".format(so.name, so.name) for so in existing_sales_order_against_customer]
 				frappe.throw(_("Cannot create Sales Order. Kindly close the following sale orders first: {0}").format(", ".join(existing_sales_order_links)))


### PR DESCRIPTION
**Validations on sales order for CSD Units**:

1. Sales order cannot be created unless a sales order that is not closed or cancelled against the customer already exists
2. Sales order cannot be closed unless a delivery note or sales invoice against it are at draft level